### PR TITLE
Rust export

### DIFF
--- a/next/components/canvas.tsx
+++ b/next/components/canvas.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import type Konva from 'konva'
-import { useState, useRef } from 'react'
+import { useState, useRef, useEffect } from 'react'
 import {
   Circle,
   Image,
@@ -21,6 +21,11 @@ function Canvas() {
 
   const [selected, setSelected] = useState<any>(null)
   const transformerRef = useRef<Konva.Transformer>(null)
+
+  useEffect(() => {
+    transformerRef.current?.nodes(selected ? [selected] : [])
+    transformerRef.current?.getLayer()?.batchDraw()
+  }, [selected])
 
   // Handler for when a box is transformed (scaled/rotated/resized)
   const handleTransformEnd = (index: number) => {

--- a/next/components/render-panel.tsx
+++ b/next/components/render-panel.tsx
@@ -185,7 +185,7 @@ export default function RenderPanel() {
             boxWidth,
             boxHeight,
             fontToUse,
-            0.1
+            0.05  // Reduced padding from 0.1 (10%) to 0.05 (5%) for larger text
           )
           fontMetrics = {
             ...classic,

--- a/next/components/topbar.tsx
+++ b/next/components/topbar.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Image, Moon, Sun } from 'lucide-react'
+import { Image, Moon, Sun, Clipboard } from 'lucide-react'
 import { Button, IconButton, Badge } from '@radix-ui/themes'
 import { fileOpen } from 'browser-fs-access'
 import { useEditorStore } from '@/lib/state'
@@ -27,6 +27,33 @@ function Topbar() {
     }
   }
 
+  const handlePasteImage = async () => {
+    try {
+      const clipboardItems = await navigator.clipboard.read()
+      let blob: Blob | null = null
+
+      for (const item of clipboardItems) {
+        for (const type of item.types) {
+          if (type.startsWith('image/')) {
+            blob = await item.getType(type)
+            break
+          }
+        }
+        if (blob) break
+      }
+
+      if (!blob) {
+        alert('No image found in clipboard.')
+        return
+      }
+
+      const image = await createImageFromBlob(blob)
+      setImage(image)
+    } catch (err) {
+      alert(`Error pasting image: ${err}`)
+    }
+  }
+
   const stageLabels = {
     original: 'Original',
     textless: 'Textless',
@@ -39,6 +66,9 @@ function Topbar() {
       <div className='mx-1 flex items-center'>
         <Button onClick={handleOpenImage} variant='soft'>
           <Image size={20} />
+        </Button>
+        <Button onClick={handlePasteImage} variant='soft'>
+          <Clipboard size={20} />
         </Button>
       </div>
 

--- a/next/components/topbar.tsx
+++ b/next/components/topbar.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import { Image, Moon, Sun, Clipboard } from 'lucide-react'
-import { Button, IconButton, Badge } from '@radix-ui/themes'
+import { Image, Moon, Sun, Clipboard, ChevronUp, ChevronDown } from 'lucide-react'
+import { Button, IconButton, Badge, Slider } from '@radix-ui/themes'
 import { fileOpen } from 'browser-fs-access'
 import { useEditorStore } from '@/lib/state'
 import { createImageFromBlob } from '@/lib/image'
@@ -9,7 +9,7 @@ import SettingsDialog from './settings-dialog'
 import DetectionControls from './detection-controls'
 
 function Topbar() {
-  const { setImage, theme, setTheme, tool, currentStage, setCurrentStage, pipelineStages, renderMethod } = useEditorStore()
+  const { setImage, theme, setTheme, tool, currentStage, setCurrentStage, pipelineStages, renderMethod, textBlocks, fontSizeStep, setFontSizeStep, setTextBlocks } = useEditorStore()
 
   const handleOpenImage = async () => {
     try {
@@ -52,6 +52,22 @@ function Topbar() {
     } catch (err) {
       alert(`Error pasting image: ${err}`)
     }
+  }
+
+  const increaseFontSize = () => {
+    const updated = textBlocks.map(block => ({
+      ...block,
+      fontSize: Math.max(1, (block.fontSize || 16) + fontSizeStep)
+    }))
+    setTextBlocks(updated)
+  }
+
+  const decreaseFontSize = () => {
+    const updated = textBlocks.map(block => ({
+      ...block,
+      fontSize: Math.max(1, (block.fontSize || 16) - fontSizeStep)
+    }))
+    setTextBlocks(updated)
   }
 
   const stageLabels = {
@@ -110,6 +126,35 @@ function Topbar() {
       </div>
 
       <div className='mx-1 flex items-center gap-1'>
+        {textBlocks.some(b => b.translatedText) && (
+          <>
+            <div className='flex items-center gap-2'>
+              <span className='text-sm'>Font Size Step:</span>
+              <Slider
+                value={[fontSizeStep]}
+                onValueChange={(value) => setFontSizeStep(value[0])}
+                min={1}
+                max={10}
+                step={1}
+                className='w-16'
+              />
+              <input
+                type='number'
+                value={fontSizeStep}
+                onChange={(e) => setFontSizeStep(parseInt(e.target.value) || 1)}
+                min={1}
+                max={10}
+                className='w-12 px-1 py-0.5 text-sm border rounded'
+              />
+            </div>
+            <Button onClick={decreaseFontSize} size='1' variant='soft'>
+              <ChevronDown size={16} /> A
+            </Button>
+            <Button onClick={increaseFontSize} size='1' variant='soft'>
+              <ChevronUp size={16} /> A
+            </Button>
+          </>
+        )}
         <IconButton
           variant='ghost'
           onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}

--- a/next/lib/state.ts
+++ b/next/lib/state.ts
@@ -208,6 +208,7 @@ export const useEditorStore = create(
       inpaintingConfig: INPAINTING_PRESETS.balanced,
       inpaintingPreset: 'balanced' as 'fast' | 'balanced' | 'quality' | 'custom',
       defaultFont: loadDefaultFont(),
+      fontSizeStep: 2,
     } as {
       image: Image | null
       tool: string
@@ -234,6 +235,7 @@ export const useEditorStore = create(
       inpaintingConfig: InpaintingConfig
       inpaintingPreset: 'fast' | 'balanced' | 'quality' | 'custom'
       defaultFont: string
+      fontSizeStep: number
     },
     (set) => ({
       setImage: (image: Image | null) => set({
@@ -334,6 +336,7 @@ export const useEditorStore = create(
         }
         set({ defaultFont: font })
       },
+      setFontSizeStep: (step: number) => set({ fontSizeStep: step }),
     })
   )
 )

--- a/next/lib/state.ts
+++ b/next/lib/state.ts
@@ -236,7 +236,20 @@ export const useEditorStore = create(
       defaultFont: string
     },
     (set) => ({
-      setImage: (image: Image | null) => set({ image }),
+      setImage: (image: Image | null) => set({
+        image,
+        currentStage: 'original',
+        pipelineStages: {
+          original: null,
+          textless: null,
+          withRectangles: null,
+          final: null,
+        },
+        textBlocks: [],
+        segmentationMask: null,
+        inpaintedImage: null,
+        selectedBlockIndex: null,
+      }),
       setTool: (tool: string) => set({ tool }),
       setScale: (scale: number) => set({ scale }),
       setTextBlocks: (textBlocks: TextBlock[]) => set({ textBlocks }),

--- a/next/utils/improved-font-sizing.ts
+++ b/next/utils/improved-font-sizing.ts
@@ -82,7 +82,7 @@ function estimateInitialFontSize(
   const boxArea = boxWidth * boxHeight
 
   // If mask stats available, use actual text area
-  const maskArea = block.maskStats?.area || boxArea * 0.5
+  const maskArea = block.maskStats?.area || boxArea * 0.7  // Increased from 0.5 for better fallback
 
   // Estimate glyphs per line based on layout mode
   const avgGlyphsPerLine = strategy.mode === 'vertical-narrow' ? 5 : 10
@@ -92,7 +92,7 @@ function estimateInitialFontSize(
   const targetArea = boxArea * strategy.targetCoverageRatio
 
   // Solve: fontSize^2 * text.length * density = targetArea
-  const glyphDensity = 0.7 // Empirical constant (glyph area as fraction of em-square)
+  const glyphDensity = 0.85 // Increased from 0.7 for better CJK text density estimation
   const fontSize = Math.sqrt(targetArea / (text.length * glyphDensity))
 
   // Clamp to reasonable range
@@ -275,19 +275,19 @@ function calculatePenalty(
 ): number {
   let penalty = 0
 
-  // Hard constraint: overflow
+  // Hard constraint: overflow (reduced penalty to allow larger text)
   if (width > maxWidth) {
-    penalty += (width - maxWidth) * 100
+    penalty += (width - maxWidth) * 50  // Reduced from 100
   }
 
   if (height > maxHeight) {
-    penalty += (height - maxHeight) * 100
+    penalty += (height - maxHeight) * 50  // Reduced from 100
   }
 
-  // Soft constraint: deviation from target coverage
+  // Soft constraint: deviation from target coverage (increased weight)
   const actualCoverage = (width * height) / (maxWidth * maxHeight)
   const coverageDeviation = Math.abs(actualCoverage - targetCoverage)
-  penalty += coverageDeviation * 50
+  penalty += coverageDeviation * 75  // Increased from 50 to prefer larger text
 
   // Soft constraint: raggedness (variance in line lengths)
   if (lines.length > 1) {

--- a/next/utils/layout-classification.ts
+++ b/next/utils/layout-classification.ts
@@ -47,7 +47,7 @@ export function classifyLayout(block: TextBlock): LayoutStrategy {
       mode: 'caption',
       preferredAlignment: 'top',
       columnWidthRatio: 0.95,
-      targetCoverageRatio: 0.6,
+      targetCoverageRatio: 0.75,  // Increased from 0.6 for better visual size
       lineHeightMultiplier: 1.3,
       letterSpacingAdjustment: 0,
     }
@@ -59,7 +59,7 @@ export function classifyLayout(block: TextBlock): LayoutStrategy {
       mode: 'vertical-narrow',
       preferredAlignment: 'center',
       columnWidthRatio: 0.7,  // Narrow column to mimic vertical stacking
-      targetCoverageRatio: 0.75,
+      targetCoverageRatio: 0.85,  // Increased from 0.75 for better visual size
       lineHeightMultiplier: 1.4,
       letterSpacingAdjustment: 1,
     }
@@ -72,7 +72,7 @@ export function classifyLayout(block: TextBlock): LayoutStrategy {
       preferredAlignment: determineCentroidAlignment(centroid, boxWidth, boxHeight),
       rotationDeg: orientationDeg,
       columnWidthRatio: 0.85,
-      targetCoverageRatio: 0.7,
+      targetCoverageRatio: 0.8,  // Increased from 0.7 for better visual size
       lineHeightMultiplier: 1.2,
       letterSpacingAdjustment: 0,
     }
@@ -83,7 +83,7 @@ export function classifyLayout(block: TextBlock): LayoutStrategy {
     mode: 'horizontal-standard',
     preferredAlignment: 'center',
     columnWidthRatio: 0.9,
-    targetCoverageRatio: 0.75,
+    targetCoverageRatio: 0.85,  // Increased from 0.75 for better visual size
     lineHeightMultiplier: 1.2,
     letterSpacingAdjustment: 0,
   }

--- a/src-tauri/assets/fonts/README.md
+++ b/src-tauri/assets/fonts/README.md
@@ -1,18 +1,39 @@
-# Font Asset Required
+# Font Assets Required
+
+## Noto Sans Regular
 
 Download Noto Sans Regular font and place it here as `NotoSans-Regular.ttf`
 
-## Download Link:
+### Download Link:
 https://github.com/notofonts/noto-fonts/raw/main/hinted/ttf/NotoSans/NotoSans-Regular.ttf
 
-## PowerShell Command:
+### PowerShell Command:
 ```powershell
 Invoke-WebRequest -Uri "https://github.com/notofonts/noto-fonts/raw/main/hinted/ttf/NotoSans/NotoSans-Regular.ttf" -OutFile "NotoSans-Regular.ttf"
 ```
 
-## Or use curl:
+### Or use curl:
 ```bash
 curl -L -o NotoSans-Regular.ttf https://github.com/notofonts/noto-fonts/raw/main/hinted/ttf/NotoSans/NotoSans-Regular.ttf
 ```
 
 The Rust code expects this file at build time via `include_bytes!("../assets/fonts/NotoSans-Regular.ttf")`
+
+## GoNotoCJKCore (Comprehensive Unicode)
+
+Download the comprehensive Unicode font and place it here as `GoNotoCJKCore.ttf`
+
+### Download Link:
+https://github.com/satbyy/go-noto-universal/releases/download/v7.0/GoNotoCJKCore.ttf
+
+### PowerShell Command:
+```powershell
+Invoke-WebRequest -Uri "https://github.com/satbyy/go-noto-universal/releases/download/v7.0/GoNotoCJKCore.ttf" -OutFile "GoNotoCJKCore.ttf"
+```
+
+### Or use curl:
+```bash
+curl -L -o GoNotoCJKCore.ttf https://github.com/satbyy/go-noto-universal/releases/download/v7.0/GoNotoCJKCore.ttf
+```
+
+The Rust code expects this file at build time via `include_bytes!("../assets/fonts/GoNotoCJKCore.ttf")`


### PR DESCRIPTION
Changed export pipeline to use rust.
This pull request introduces several improvements to text block rendering, font sizing, and user interface controls for image and text editing. The most significant changes include new UI controls for font size adjustment, improved font sizing logic for better visual appearance (especially for CJK text), and enhancements to image loading and state management. These updates aim to provide users with more control and better default behavior when editing images and text.

**UI Enhancements and Controls**
* Added font size step adjustment controls to the top bar, including a slider, input field, and increase/decrease buttons, allowing users to fine-tune text block font sizes interactively (`next/components/topbar.tsx`, `next/lib/state.ts`). [[1]](diffhunk://#diff-5a4c05c33fbc97279fd73cd58fc16b341f4a07998e0c40566f11704c6a6f79a2R129-R157) [[2]](diffhunk://#diff-8a8c650b70ee4197d3fd364f650c0daa30c7bcb62a7a9e6a650d558f784649d4R211) [[3]](diffhunk://#diff-8a8c650b70ee4197d3fd364f650c0daa30c7bcb62a7a9e6a650d558f784649d4R339)
* Implemented a "Paste Image" button in the top bar, enabling users to paste images directly from the clipboard (`next/components/topbar.tsx`). [[1]](diffhunk://#diff-5a4c05c33fbc97279fd73cd58fc16b341f4a07998e0c40566f11704c6a6f79a2R86-R88) [[2]](diffhunk://#diff-5a4c05c33fbc97279fd73cd58fc16b341f4a07998e0c40566f11704c6a6f79a2R30-R72)

**Font Sizing and Layout Improvements**
* Increased target coverage ratios and glyph density in font sizing and layout classification logic to produce larger, visually balanced text blocks, especially for CJK scripts (`next/utils/improved-font-sizing.ts`, `next/utils/layout-classification.ts`). [[1]](diffhunk://#diff-f2279727ad7be06e90d4257024045688b4096f5a2863020c840a1a8836ff22cdL85-R85) [[2]](diffhunk://#diff-f2279727ad7be06e90d4257024045688b4096f5a2863020c840a1a8836ff22cdL95-R95) [[3]](diffhunk://#diff-25f200b7abf21a669fb0350e6f76f6bd88a6a022ba25a028f945de7a11f0c75cL50-R50) [[4]](diffhunk://#diff-25f200b7abf21a669fb0350e6f76f6bd88a6a022ba25a028f945de7a11f0c75cL62-R62) [[5]](diffhunk://#diff-25f200b7abf21a669fb0350e6f76f6bd88a6a022ba25a028f945de7a11f0c75cL75-R75) [[6]](diffhunk://#diff-25f200b7abf21a669fb0350e6f76f6bd88a6a022ba25a028f945de7a11f0c75cL86-R86)
* Reduced overflow penalty and increased coverage deviation penalty in the font sizing algorithm to favor larger text while minimizing overflow (`next/utils/improved-font-sizing.ts`).
* Reduced text block padding for larger text rendering in the classic font metrics calculation (`next/components/render-panel.tsx`).

**State Management and Initialization**
* When loading a new image, the editor state resets all relevant fields (stages, text blocks, segmentation mask, etc.) to ensure a clean slate for editing (`next/lib/state.ts`).

**Konva Canvas Selection**
* Added a `useEffect` hook to synchronize the Konva transformer selection when a text block is selected, ensuring the correct node is transformed (`next/components/canvas.tsx`). [[1]](diffhunk://#diff-6960a80e476b808bc4b54403238d58cfc3f4595adbaa4d0173e7d0e9e1e8c81aL4-R4) [[2]](diffhunk://#diff-6960a80e476b808bc4b54403238d58cfc3f4595adbaa4d0173e7d0e9e1e8c81aR25-R29)

**Documentation**
* Updated font asset documentation to include instructions for downloading and placing both Noto Sans Regular and GoNotoCJKCore fonts required by the Rust backend (`src-tauri/assets/fonts/README.md`).